### PR TITLE
Rohan/2 search pane course catalog

### DIFF
--- a/src/components/CombinationContainer/index.tsx
+++ b/src/components/CombinationContainer/index.tsx
@@ -58,7 +58,7 @@ export default function CombinationContainer(): React.ReactElement {
   const handleChangeKeyword = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
       let input = e.target.value.trim();
-      const results = /^([A-Z]+)(\d.*)$/i.exec(input);
+      const results = /^([a-z]+)(\d.*)$/i.exec(input);
       if (results != null) {
         const [, subject, number] = results as unknown as [
           string,
@@ -107,71 +107,36 @@ export default function CombinationContainer(): React.ReactElement {
 
   return (
     <>
-      <div className="CombinationContainer">
-        <title className="title">Search for a course</title>
+      <div className="CourseAdd">
+        <div className="add">
+          <div className="primary">
+            <FontAwesomeIcon className="icon" fixedWidth icon={faSearch} />
+            <div className="keyword-wrapper">
+              <input
+                type="text"
+                placeholder="Subject or course number"
+                ref={inputRef}
+                value={keyword}
+                onChange={handleChangeKeyword}
+                className="keyword"
+              />
+            </div>
+          </div>
 
-        <div className="scroller">
-          <AutoSizer>
-            {({ width, height }): React.ReactElement => (
-              <List
-                width={width}
-                height={height}
-                style={{ outline: 'none' }}
-                rowCount={sortedCombinations.length}
-                rowHeight={160}
-                rowRenderer={({ index, key, style }): React.ReactElement => {
-                  const { crns } = sortedCombinations[index] as Combination;
-                  return (
-                    <div className="list-item" style={style} key={key}>
-                      <div
-                        className="combination"
-                        onMouseEnter={(): void => setOverlayCrns(crns)}
-                        onMouseLeave={(): void => setOverlayCrns([])}
-                        onClick={(): void =>
-                          patchSchedule({
-                            pinnedCrns: [...pinnedCrns, ...crns],
-                          })
-                        }
-                      >
-                        <FontAwesomeIcon
-                          className="icon"
-                          fixedWidth
-                          icon={faSearch}
-                        />
-                      </div>
-                    </div>
-                  );
-                }}
-              />
-            )}
-          </AutoSizer>
-          <div>
-            <input
-              type="text"
-              ref={inputRef}
-              value={keyword}
-              onChange={handleChangeKeyword}
-              className="keyword"
-              placeholder="Subject or course number"
-              style={{ width: '230px' }}
+          {[
+            ['Credit Hours & Class Times', 'creditHours', CREDIT] as const,
+            ['Delivery Mode', 'deliveryMode', DELIVERY_MODES] as const,
+            ['Campus', 'campus', CAMPUSES] as const,
+          ].map(([name, property, labels]) => (
+            <CourseFilter
+              key={property}
+              name={name}
+              labels={labels}
+              selectedTags={filter[property]}
+              onReset={(): void => handleResetFilter(property)}
+              onToggle={(tag): void => handleToggleFilter(property, tag)}
             />
-          </div>
-          <div className="dropDown">
-            {[
-              ['Credit Hours & Class Times', 'creditHours', CREDIT] as const,
-              ['Delivery Mode', 'deliveryMode', DELIVERY_MODES] as const,
-              ['Campus', 'campus', CAMPUSES] as const,
-            ].map(([name, property, labels]) => (
-              <CourseFilter
-                key={property}
-                name={name}
-                labels={labels}
-                selectedTags={filter[property]}
-                onReset={(): void => handleResetFilter(property)}
-                onToggle={(tag): void => handleToggleFilter(property, tag)}
-              />
-            ))}
-          </div>
+          ))}
         </div>
       </div>
 

--- a/src/components/CombinationContainer/index.tsx
+++ b/src/components/CombinationContainer/index.tsx
@@ -1,32 +1,10 @@
-/* eslint-disable react/jsx-no-bind */
-/* eslint-disable @typescript-eslint/no-unused-vars */
-/* eslint-disable func-names */
-/* eslint-disable import/no-duplicates */
-import React, {
-  ChangeEvent,
-  useEffect,
-  KeyboardEvent,
-  useCallback,
-  useContext,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import React, { useCallback, useContext, useMemo, useState } from 'react';
 import { AutoSizer, List } from 'react-virtualized';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faSearch } from '@fortawesome/free-solid-svg-icons';
 
-import { Course, CourseFilter } from '..';
 import { Button, Calendar, Select } from '..';
 import { OverlayCrnsContext, ScheduleContext } from '../../contexts';
 import { Combination } from '../../types';
 import Modal from '../Modal';
-import {
-  ASYNC_DELIVERY_MODE,
-  CAMPUSES,
-  DELIVERY_MODES,
-  CREDIT,
-} from '../../constants';
 
 import 'react-virtualized/styles.css';
 import './stylesheet.scss';
@@ -51,92 +29,64 @@ export default function CombinationContainer(): React.ReactElement {
     () => oscar.sortCombinations(combinations, sortingOptionIndex),
     [oscar, combinations, sortingOptionIndex]
   );
-  const [keyword, setKeyword] = useState('');
-
-  const inputRef = useRef<HTMLInputElement | null>(null);
-
-  const handleChangeKeyword = useCallback(
-    (e: ChangeEvent<HTMLInputElement>) => {
-      let input = e.target.value.trim();
-      const results = /^([a-z]+)(\d.*)$/i.exec(input);
-      if (results != null) {
-        const [, subject, number] = results as unknown as [
-          string,
-          string,
-          string
-        ];
-        input = `${subject} ${number}`;
-      }
-      setKeyword(input);
-    },
-    []
-  );
-  type SortKey = 'deliveryMode' | 'campus' | 'creditHours';
-
-  type SortFilter = {
-    [sortKey in SortKey]: string[];
-  };
-
-  const [filter, setFilter] = useState<SortFilter>({
-    deliveryMode: [],
-    campus: [],
-    creditHours: [],
-  });
-
-  const handleResetFilter = useCallback(
-    (key) => {
-      setFilter({
-        ...filter,
-        [key]: [],
-      });
-    },
-    [filter]
-  );
-  const handleToggleFilter = useCallback(
-    (key: SortKey, tag: string) => {
-      const tags = filter[key];
-      setFilter({
-        ...filter,
-        [key]: tags.includes(tag)
-          ? tags.filter((v) => v !== tag)
-          : [...tags, tag],
-      });
-    },
-    [filter]
-  );
 
   return (
     <>
-      <div className="CourseAdd">
-        <div className="add">
-          <div className="primary">
-            <FontAwesomeIcon className="icon" fixedWidth icon={faSearch} />
-            <div className="keyword-wrapper">
-              <input
-                type="text"
-                placeholder="Subject or course number"
-                ref={inputRef}
-                value={keyword}
-                onChange={handleChangeKeyword}
-                className="keyword"
+      <div className="CombinationContainer">
+        <Select
+          onChange={(newSortingOptionIndex): void =>
+            patchSchedule({ sortingOptionIndex: newSortingOptionIndex })
+          }
+          current={sortingOptionIndex}
+          options={oscar.sortingOptions.map((sortingOption, i) => ({
+            id: i,
+            label: sortingOption.label,
+          }))}
+        />
+        <Button
+          className="reset"
+          onClick={handleResetPinnedCrns}
+          disabled={pinnedCrns.length === 0}
+        >
+          Reset Sections
+        </Button>
+        <div className="scroller">
+          <AutoSizer>
+            {({ width, height }): React.ReactElement => (
+              <List
+                width={width}
+                height={height}
+                style={{ outline: 'none' }}
+                rowCount={sortedCombinations.length}
+                rowHeight={108}
+                rowRenderer={({ index, key, style }): React.ReactElement => {
+                  const { crns } = sortedCombinations[index] as Combination;
+                  return (
+                    <div className="list-item" style={style} key={key}>
+                      <div
+                        className="combination"
+                        onMouseEnter={(): void => setOverlayCrns(crns)}
+                        onMouseLeave={(): void => setOverlayCrns([])}
+                        onClick={(): void =>
+                          patchSchedule({
+                            pinnedCrns: [...pinnedCrns, ...crns],
+                          })
+                        }
+                      >
+                        <div className="number">{index + 1}</div>
+                        <Calendar
+                          className="calendar-preview"
+                          overlayCrns={crns}
+                          isAutosized
+                          preview
+                        />
+                      </div>
+                    </div>
+                  );
+                }}
               />
-            </div>
-          </div>
-
-          {[
-            ['Credit Hours & Class Times', 'creditHours', CREDIT] as const,
-            ['Delivery Mode', 'deliveryMode', DELIVERY_MODES] as const,
-            ['Campus', 'campus', CAMPUSES] as const,
-          ].map(([name, property, labels]) => (
-            <CourseFilter
-              key={property}
-              name={name}
-              labels={labels}
-              selectedTags={filter[property]}
-              onReset={(): void => handleResetFilter(property)}
-              onToggle={(tag): void => handleToggleFilter(property, tag)}
-            />
-          ))}
+            )}
+          </AutoSizer>
         </div>
       </div>
 

--- a/src/components/CombinationContainer/index.tsx
+++ b/src/components/CombinationContainer/index.tsx
@@ -1,10 +1,32 @@
-import React, { useCallback, useContext, useMemo, useState } from 'react';
+/* eslint-disable react/jsx-no-bind */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable func-names */
+/* eslint-disable import/no-duplicates */
+import React, {
+  ChangeEvent,
+  useEffect,
+  KeyboardEvent,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { AutoSizer, List } from 'react-virtualized';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faSearch } from '@fortawesome/free-solid-svg-icons';
 
+import { Course, CourseFilter } from '..';
 import { Button, Calendar, Select } from '..';
 import { OverlayCrnsContext, ScheduleContext } from '../../contexts';
 import { Combination } from '../../types';
 import Modal from '../Modal';
+import {
+  ASYNC_DELIVERY_MODE,
+  CAMPUSES,
+  DELIVERY_MODES,
+  CREDIT,
+} from '../../constants';
 
 import 'react-virtualized/styles.css';
 import './stylesheet.scss';
@@ -29,27 +51,65 @@ export default function CombinationContainer(): React.ReactElement {
     () => oscar.sortCombinations(combinations, sortingOptionIndex),
     [oscar, combinations, sortingOptionIndex]
   );
+  const [keyword, setKeyword] = useState('');
+
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const handleChangeKeyword = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      let input = e.target.value.trim();
+      const results = /^([A-Z]+)(\d.*)$/i.exec(input);
+      if (results != null) {
+        const [, subject, number] = results as unknown as [
+          string,
+          string,
+          string
+        ];
+        input = `${subject} ${number}`;
+      }
+      setKeyword(input);
+    },
+    []
+  );
+  type SortKey = 'deliveryMode' | 'campus' | 'creditHours';
+
+  type SortFilter = {
+    [sortKey in SortKey]: string[];
+  };
+
+  const [filter, setFilter] = useState<SortFilter>({
+    deliveryMode: [],
+    campus: [],
+    creditHours: [],
+  });
+
+  const handleResetFilter = useCallback(
+    (key) => {
+      setFilter({
+        ...filter,
+        [key]: [],
+      });
+    },
+    [filter]
+  );
+  const handleToggleFilter = useCallback(
+    (key: SortKey, tag: string) => {
+      const tags = filter[key];
+      setFilter({
+        ...filter,
+        [key]: tags.includes(tag)
+          ? tags.filter((v) => v !== tag)
+          : [...tags, tag],
+      });
+    },
+    [filter]
+  );
 
   return (
     <>
       <div className="CombinationContainer">
-        <Select
-          onChange={(newSortingOptionIndex): void =>
-            patchSchedule({ sortingOptionIndex: newSortingOptionIndex })
-          }
-          current={sortingOptionIndex}
-          options={oscar.sortingOptions.map((sortingOption, i) => ({
-            id: i,
-            label: sortingOption.label,
-          }))}
-        />
-        <Button
-          className="reset"
-          onClick={handleResetPinnedCrns}
-          disabled={pinnedCrns.length === 0}
-        >
-          Reset Sections
-        </Button>
+        <title className="title">Search for a course</title>
+
         <div className="scroller">
           <AutoSizer>
             {({ width, height }): React.ReactElement => (
@@ -58,7 +118,7 @@ export default function CombinationContainer(): React.ReactElement {
                 height={height}
                 style={{ outline: 'none' }}
                 rowCount={sortedCombinations.length}
-                rowHeight={108}
+                rowHeight={160}
                 rowRenderer={({ index, key, style }): React.ReactElement => {
                   const { crns } = sortedCombinations[index] as Combination;
                   return (
@@ -73,12 +133,10 @@ export default function CombinationContainer(): React.ReactElement {
                           })
                         }
                       >
-                        <div className="number">{index + 1}</div>
-                        <Calendar
-                          className="calendar-preview"
-                          overlayCrns={crns}
-                          isAutosized
-                          preview
+                        <FontAwesomeIcon
+                          className="icon"
+                          fixedWidth
+                          icon={faSearch}
                         />
                       </div>
                     </div>
@@ -87,6 +145,33 @@ export default function CombinationContainer(): React.ReactElement {
               />
             )}
           </AutoSizer>
+          <div>
+            <input
+              type="text"
+              ref={inputRef}
+              value={keyword}
+              onChange={handleChangeKeyword}
+              className="keyword"
+              placeholder="Subject or course number"
+              style={{ width: '230px' }}
+            />
+          </div>
+          <div className="dropDown">
+            {[
+              ['Credit Hours & Class Times', 'creditHours', CREDIT] as const,
+              ['Delivery Mode', 'deliveryMode', DELIVERY_MODES] as const,
+              ['Campus', 'campus', CAMPUSES] as const,
+            ].map(([name, property, labels]) => (
+              <CourseFilter
+                key={property}
+                name={name}
+                labels={labels}
+                selectedTags={filter[property]}
+                onReset={(): void => handleResetFilter(property)}
+                onToggle={(tag): void => handleToggleFilter(property, tag)}
+              />
+            ))}
+          </div>
         </div>
       </div>
 

--- a/src/components/CombinationContainer/stylesheet.scss
+++ b/src/components/CombinationContainer/stylesheet.scss
@@ -1,81 +1,57 @@
-@import "../../variables";
+@import '../../variables';
 
-.CourseAdd {
+.CombinationContainer {
   display: flex;
   flex-direction: column;
   align-items: stretch;
   border-right: 1px solid $color-border;
-  width: 400px;
 
-  .add {
-    @include card;
-    background-color: $color-border;
+  .scroller {
+    flex: 1;
+    overflow-y: auto;
     display: flex;
     flex-direction: column;
     align-items: stretch;
+    padding: 4px;
+    width: 256px;
+    margin-bottom: -1px;
 
-    .primary {
+    .list-item {
       display: flex;
-      align-items: center;
+      align-items: stretch;
+      height: 108px;
 
-      .icon {
-        margin-left: 8px;
-        color: $color-neutral;
-        transition: color .2s;
-
-        &.active {
-          color: inherit;
-        }
-      }
-
-      .keyword-wrapper {
+      .combination {
+        @include card;
         flex: 1;
         display: flex;
-        align-items: center;
-        position: relative;
-        
+        align-items: stretch;
 
-        .keyword {
-          position: relative;
-          flex-direction: row;
-          background: none;
-          border: none;
-          outline: none;
-          font-size: 1em;
+        .number {
+          background-color: $color-border;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          width: 36px;
+
+          font-size: .8em;
           font-weight: bold;
-          height: 40px;
-        
-          
+        }
 
-          &::placeholder {
-            font-weight: normal;
-            color: $color-neutral;
-            text-transform: none;
-          }
-
-          &.autocomplete {
-            position: absolute;
-            opacity: .5;
-          }
+        .calendar-preview {
+          flex: 1;
+          cursor: pointer;
         }
       }
     }
   }
+}
 
-  .Course {
-    background-color: $color-border;
-    opacity: .6;
-    transition: opacity .2s;
+.mobile .CombinationContainer {
+  flex: 1;
+  border-right: none;
 
-    &:hover,
-    &.active {
-      opacity: 1;
-    }
-  }
-
-  .disclaimer {
-    color: $color-neutral;
-    padding: 4px;
-    font-size: .8em;
+  .scroller {
+    width: auto;
   }
 }

--- a/src/components/CombinationContainer/stylesheet.scss
+++ b/src/components/CombinationContainer/stylesheet.scss
@@ -1,113 +1,81 @@
-@import '../../variables';
+@import "../../variables";
 
-.CombinationContainer {
+.CourseAdd {
   display: flex;
   flex-direction: column;
   align-items: stretch;
   border-right: 1px solid $color-border;
   width: 400px;
 
-  .title {
-    display: flex;
-    align-items: stretch;
-    margin: 10px;
-  }
-  
-  
-
-  
-  .scroller {
-    flex: 1;
-    overflow-y: auto;
+  .add {
+    @include card;
+    background-color: $color-border;
     display: flex;
     flex-direction: column;
     align-items: stretch;
-    padding: 4px;
-    width: 256px;
-    margin-bottom: -1px;
-    width: 400px;
-    
 
-    .icon {
-      margin: 8px;
+    .primary {
+      display: flex;
+      align-items: center;
 
-      color: $color-neutral;
-      transition: color .2s;
-    }
-
-    
-    
-    .keyword {
-      position: relative;
-      flex-direction: row;
-      background: none;
-      border: none;
-      outline: none;
-      font-size: 1em;
-      font-weight: bold;
-      height: 40px;
-      margin-left: 35px;
-      
-  
-      &::placeholder {
-        font-weight: normal;
+      .icon {
+        margin-left: 8px;
         color: $color-neutral;
-      }
-  
-      &.autocomplete {
-        position: absolute;
-        opacity: .5;
-      }
-    
+        transition: color .2s;
+
         &.active {
           color: inherit;
         }
       }
-      .dropDown {
-        display: flex;
-        align-items: stretch;
-        flex-direction: column;
-        
-      }
 
-    .list-item {
-      display: flex;
-      align-items: stretch;
-      height: 108px;
-      background-color: $color-border;
-
-      .combination {
-        @include card;
+      .keyword-wrapper {
         flex: 1;
-        flex-direction: column;
         display: flex;
-        align-items: stretch;
+        align-items: center;
+        position: relative;
+        
 
-        .number {
-          background-color: $color-border;
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          width: 36px;
-
-          font-size: .8em;
+        .keyword {
+          position: relative;
+          flex-direction: row;
+          background: none;
+          border: none;
+          outline: none;
+          font-size: 1em;
           font-weight: bold;
-        }
+          height: 40px;
+        
+          
 
-        .calendar-preview {
-          flex: 1;
-          cursor: pointer;
+          &::placeholder {
+            font-weight: normal;
+            color: $color-neutral;
+            text-transform: none;
+          }
+
+          &.autocomplete {
+            position: absolute;
+            opacity: .5;
+          }
         }
       }
     }
   }
-}
 
-.mobile .CombinationContainer {
-  flex: 1;
-  border-right: none;
+  .Course {
+    background-color: $color-border;
+    opacity: .6;
+    transition: opacity .2s;
 
-  .scroller {
-    width: auto;
+    &:hover,
+    &.active {
+      opacity: 1;
+    }
+  }
+
+  .disclaimer {
+    color: $color-neutral;
+    padding: 4px;
+    font-size: .8em;
   }
 }

--- a/src/components/CombinationContainer/stylesheet.scss
+++ b/src/components/CombinationContainer/stylesheet.scss
@@ -5,7 +5,17 @@
   flex-direction: column;
   align-items: stretch;
   border-right: 1px solid $color-border;
+  width: 400px;
 
+  .title {
+    display: flex;
+    align-items: stretch;
+    margin: 10px;
+  }
+  
+  
+
+  
   .scroller {
     flex: 1;
     overflow-y: auto;
@@ -15,15 +25,61 @@
     padding: 4px;
     width: 256px;
     margin-bottom: -1px;
+    width: 400px;
+    
+
+    .icon {
+      margin: 8px;
+
+      color: $color-neutral;
+      transition: color .2s;
+    }
+
+    
+    
+    .keyword {
+      position: relative;
+      flex-direction: row;
+      background: none;
+      border: none;
+      outline: none;
+      font-size: 1em;
+      font-weight: bold;
+      height: 40px;
+      margin-left: 35px;
+      
+  
+      &::placeholder {
+        font-weight: normal;
+        color: $color-neutral;
+      }
+  
+      &.autocomplete {
+        position: absolute;
+        opacity: .5;
+      }
+    
+        &.active {
+          color: inherit;
+        }
+      }
+      .dropDown {
+        display: flex;
+        align-items: stretch;
+        flex-direction: column;
+        
+      }
 
     .list-item {
       display: flex;
       align-items: stretch;
       height: 108px;
+      background-color: $color-border;
 
       .combination {
         @include card;
         flex: 1;
+        flex-direction: column;
         display: flex;
         align-items: stretch;
 

--- a/src/components/CourseAdd/index.tsx
+++ b/src/components/CourseAdd/index.tsx
@@ -219,6 +219,7 @@ export default function CourseAdd({
             />
           </div>
         </div>
+
         {[
           ['Delivery Mode', 'deliveryMode', DELIVERY_MODES] as const,
           ['Campus', 'campus', CAMPUSES] as const,

--- a/src/components/CourseFilter/index.tsx
+++ b/src/components/CourseFilter/index.tsx
@@ -5,6 +5,7 @@ import { faAngleDown, faAngleUp } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import { classes, humanizeArrayReact } from '../../utils/misc';
+import { TIMES } from '../../constants';
 
 import './stylesheet.scss';
 
@@ -52,36 +53,212 @@ export default function CourseFilter({
       </div>
       {expanded && (
         <div className="tag-container">
-          <div
-            className={classes('tag', selectedTags.length === 0 && 'active')}
-            onClick={onReset}
-          >
-            All
-          </div>
-          {Object.keys(labels).map((tag) => (
-            <div>
-              <div className="jo">
-                {labels[tag] === 'All' && (
+          <div>
+            {!string2 && (
+              <div className="buttonContainer">
+                <div
+                  className={classes(
+                    'tag',
+                    selectedTags.length === 0 && 'active'
+                  )}
+                  onClick={onReset}
+                >
+                  All
+                </div>
+                {Object.keys(labels).map((tag) => (
                   <div>
-                    <p>5</p>
+                    <div>
+                      <div
+                        key={tag}
+                        className={classes(
+                          'tag',
+                          selectedTags.includes(tag) && 'active'
+                        )}
+                        property={tag}
+                        onClick={(): void => onToggle(tag)}
+                      >
+                        {labels[tag]}
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+          <div>
+            {string2 && (
+              <div className="subTitle">
+                <p>Credit Hours</p>
+              </div>
+            )}
+          </div>
+          <div>
+            {string2 && (
+              <div className="buttonContainer">
+                <div
+                  className={classes(
+                    'tag',
+                    selectedTags.length === 0 && 'active'
+                  )}
+                  onClick={onReset}
+                >
+                  All
+                </div>
+                {Object.keys(labels)
+                  .slice(0, 5)
+                  .map((tag) => (
+                    <div>
+                      <div className="jo">
+                        {labels[tag] === 'All' && (
+                          <div>
+                            <p>5</p>
+                          </div>
+                        )}
+                      </div>
+                      <div>
+                        <div
+                          key={tag}
+                          className={classes(
+                            'tag',
+                            selectedTags.includes(tag) && 'active'
+                          )}
+                          property={tag}
+                          onClick={(): void => onToggle(tag)}
+                        >
+                          {labels[tag]}
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+              </div>
+            )}
+          </div>
+          <div>
+            {string2 && (
+              <div className="subTitle">
+                <p>Days</p>
+              </div>
+            )}
+          </div>
+          <div>
+            {string2 && (
+              <div className="buttonContainer">
+                <div
+                  className={classes(
+                    'tag',
+                    selectedTags.length === 0 && 'active'
+                  )}
+                  onClick={onReset}
+                >
+                  All
+                </div>
+                {Object.keys(labels)
+                  .slice(5, 10)
+                  .map((tag) => (
+                    <div>
+                      <div>
+                        <div
+                          key={tag}
+                          className={classes(
+                            'tag',
+                            selectedTags.includes(tag) && 'active'
+                          )}
+                          property={tag}
+                          onClick={(): void => onToggle(tag)}
+                        >
+                          {labels[tag]}
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+              </div>
+            )}
+          </div>
+          <div>
+            <div className="timeTitles">
+              <div>
+                {string2 && (
+                  <div className="startSubTitle">
+                    <p>Start After</p>
                   </div>
                 )}
               </div>
-              <div className="buttonContainer">
-                <div
-                  key={tag}
-                  className={classes(
-                    'tag',
-                    selectedTags.includes(tag) && 'active'
-                  )}
-                  property={tag}
-                  onClick={(): void => onToggle(tag)}
-                >
-                  {labels[tag]}
-                </div>
+
+              <div>
+                {string2 && (
+                  <div className="endSubTitle">
+                    <p>End After</p>
+                  </div>
+                )}
               </div>
             </div>
-          ))}
+          </div>
+          <div>
+            {string2 && (
+              <div className="buttonContainer">
+                {Object.keys(labels)
+                  .slice(10, 12)
+                  .map((tag) => (
+                    <div>
+                      <div>
+                        <div
+                          key={tag}
+                          className={classes(
+                            'tag',
+                            selectedTags.includes(tag) && 'active'
+                          )}
+                          property={tag}
+                          onClick={(): void => onToggle(tag)}
+                        >
+                          {labels[tag]}
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+              </div>
+            )}
+          </div>
+          <div>
+            {string2 && (
+              <div className="subTitle">
+                <p>Course Level</p>
+              </div>
+            )}
+          </div>
+          <div>
+            {string2 && (
+              <div className="buttonContainer">
+                <div
+                  className={classes(
+                    'tag',
+                    selectedTags.length === 0 && 'active'
+                  )}
+                  onClick={onReset}
+                >
+                  All
+                </div>
+                {Object.keys(labels)
+                  .slice(12, 14)
+                  .map((tag) => (
+                    <div>
+                      <div>
+                        <div
+                          key={tag}
+                          className={classes(
+                            'tag',
+                            selectedTags.includes(tag) && 'active'
+                          )}
+                          property={tag}
+                          onClick={(): void => onToggle(tag)}
+                        >
+                          {labels[tag]}
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+              </div>
+            )}
+          </div>
         </div>
       )}
     </div>

--- a/src/components/CourseFilter/index.tsx
+++ b/src/components/CourseFilter/index.tsx
@@ -5,7 +5,7 @@ import { faAngleDown, faAngleUp } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import { classes, humanizeArrayReact } from '../../utils/misc';
-import { TIMES } from '../../constants';
+import { TIMES, CLASS_TIMESTAMPS } from '../../constants';
 
 import './stylesheet.scss';
 
@@ -193,7 +193,7 @@ export default function CourseFilter({
                   .map((tag) => (
                     <div>
                       <div>
-                        <div
+                        <select
                           key={tag}
                           className={classes(
                             'tag',
@@ -202,8 +202,13 @@ export default function CourseFilter({
                           property={tag}
                           onClick={(): void => onToggle(tag)}
                         >
-                          {labels[tag]}
-                        </div>
+                          {CLASS_TIMESTAMPS.map((timestamp) => (
+                            <option value={timestamp} key={timestamp}>
+                              {' '}
+                              {timestamp}{' '}
+                            </option>
+                          ))}
+                        </select>
                       </div>
                     </div>
                   ))}

--- a/src/components/CourseFilter/index.tsx
+++ b/src/components/CourseFilter/index.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-multi-assign */
-/* eslint-disable react/self-closing-comp */
 import React, { useState } from 'react';
 import { faAngleDown, faAngleUp } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';

--- a/src/components/CourseFilter/index.tsx
+++ b/src/components/CourseFilter/index.tsx
@@ -25,11 +25,10 @@ export default function CourseFilter({
   onToggle,
 }: CourseFilterProps): React.ReactElement {
   const [expanded, setExpanded] = useState(false);
-  const string2 = name === 'Credit Hours & Class Times';
+  const isCreditHourFilter = name === 'Credit Hours & Class Times';
   const buttonNumber = 4;
   let boolValue = false;
   const flipSwitch = (boolValue = !boolValue);
-
   return (
     <div className="CourseFilter">
       <div
@@ -54,7 +53,7 @@ export default function CourseFilter({
       {expanded && (
         <div className="tag-container">
           <div>
-            {!string2 && (
+            {!isCreditHourFilter && (
               <div className="buttonContainer">
                 <div
                   className={classes(
@@ -86,14 +85,14 @@ export default function CourseFilter({
             )}
           </div>
           <div>
-            {string2 && (
+            {isCreditHourFilter && (
               <div className="subTitle">
                 <p>Credit Hours</p>
               </div>
             )}
           </div>
           <div>
-            {string2 && (
+            {isCreditHourFilter && (
               <div className="buttonContainer">
                 <div
                   className={classes(
@@ -108,13 +107,6 @@ export default function CourseFilter({
                   .slice(0, 5)
                   .map((tag) => (
                     <div>
-                      <div className="jo">
-                        {labels[tag] === 'All' && (
-                          <div>
-                            <p>5</p>
-                          </div>
-                        )}
-                      </div>
                       <div>
                         <div
                           key={tag}
@@ -134,14 +126,14 @@ export default function CourseFilter({
             )}
           </div>
           <div>
-            {string2 && (
+            {isCreditHourFilter && (
               <div className="subTitle">
                 <p>Days</p>
               </div>
             )}
           </div>
           <div>
-            {string2 && (
+            {isCreditHourFilter && (
               <div className="buttonContainer">
                 <div
                   className={classes(
@@ -177,7 +169,7 @@ export default function CourseFilter({
           <div>
             <div className="timeTitles">
               <div>
-                {string2 && (
+                {isCreditHourFilter && (
                   <div className="startSubTitle">
                     <p>Start After</p>
                   </div>
@@ -185,7 +177,7 @@ export default function CourseFilter({
               </div>
 
               <div>
-                {string2 && (
+                {isCreditHourFilter && (
                   <div className="endSubTitle">
                     <p>End After</p>
                   </div>
@@ -194,7 +186,7 @@ export default function CourseFilter({
             </div>
           </div>
           <div>
-            {string2 && (
+            {isCreditHourFilter && (
               <div className="buttonContainer">
                 {Object.keys(labels)
                   .slice(10, 12)
@@ -219,14 +211,14 @@ export default function CourseFilter({
             )}
           </div>
           <div>
-            {string2 && (
+            {isCreditHourFilter && (
               <div className="subTitle">
                 <p>Course Level</p>
               </div>
             )}
           </div>
           <div>
-            {string2 && (
+            {isCreditHourFilter && (
               <div className="buttonContainer">
                 <div
                   className={classes(

--- a/src/components/CourseFilter/index.tsx
+++ b/src/components/CourseFilter/index.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable no-multi-assign */
+/* eslint-disable react/self-closing-comp */
 import React, { useState } from 'react';
 import { faAngleDown, faAngleUp } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -22,6 +24,10 @@ export default function CourseFilter({
   onToggle,
 }: CourseFilterProps): React.ReactElement {
   const [expanded, setExpanded] = useState(false);
+  const string2 = name === 'Credit Hours & Class Times';
+  const buttonNumber = 4;
+  let boolValue = false;
+  const flipSwitch = (boolValue = !boolValue);
 
   return (
     <div className="CourseFilter">
@@ -53,13 +59,27 @@ export default function CourseFilter({
             All
           </div>
           {Object.keys(labels).map((tag) => (
-            <div
-              key={tag}
-              className={classes('tag', selectedTags.includes(tag) && 'active')}
-              property={tag}
-              onClick={(): void => onToggle(tag)}
-            >
-              {labels[tag]}
+            <div>
+              <div className="jo">
+                {labels[tag] === 'All' && (
+                  <div>
+                    <p>5</p>
+                  </div>
+                )}
+              </div>
+              <div className="buttonContainer">
+                <div
+                  key={tag}
+                  className={classes(
+                    'tag',
+                    selectedTags.includes(tag) && 'active'
+                  )}
+                  property={tag}
+                  onClick={(): void => onToggle(tag)}
+                >
+                  {labels[tag]}
+                </div>
+              </div>
             </div>
           ))}
         </div>

--- a/src/components/CourseFilter/index.tsx
+++ b/src/components/CourseFilter/index.tsx
@@ -5,7 +5,7 @@ import { faAngleDown, faAngleUp } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import { classes, humanizeArrayReact } from '../../utils/misc';
-import { TIMES, CLASS_TIMESTAMPS } from '../../constants';
+import { CLASS_TIMESTAMPS } from '../../constants';
 
 import './stylesheet.scss';
 
@@ -26,9 +26,6 @@ export default function CourseFilter({
 }: CourseFilterProps): React.ReactElement {
   const [expanded, setExpanded] = useState(false);
   const isCreditHourFilter = name === 'Credit Hours & Class Times';
-  const buttonNumber = 4;
-  let boolValue = false;
-  const flipSwitch = (boolValue = !boolValue);
   return (
     <div className="CourseFilter">
       <div

--- a/src/components/CourseFilter/stylesheet.scss
+++ b/src/components/CourseFilter/stylesheet.scss
@@ -94,7 +94,6 @@
 
       &.active {
         opacity: 1;
-        font-weight: bold;
       }
 
       &:hover {

--- a/src/components/CourseFilter/stylesheet.scss
+++ b/src/components/CourseFilter/stylesheet.scss
@@ -33,11 +33,22 @@
     }
   }
 
+  
+  
+  
   .tag-container {
     display: flex;
     flex-wrap: wrap;
-    margin-top: -12px;
     padding: 8px;
+    margin-top: 20px;
+
+    .buttonContainer {
+      display: flex;
+      flex-direction: row;
+      flex-wrap: wrap;
+    }
+
+    
 
     .tag {
       @include card;
@@ -47,6 +58,7 @@
       transition: opacity .2s;
       font-size: .8em;
       cursor: pointer;
+      
 
       &.active {
         opacity: 1;
@@ -57,5 +69,7 @@
         opacity: 1;
       }
     }
-  }
+    
+  
+}
 }

--- a/src/components/CourseFilter/stylesheet.scss
+++ b/src/components/CourseFilter/stylesheet.scss
@@ -38,14 +38,46 @@
   
   .tag-container {
     display: flex;
-    flex-wrap: wrap;
+    flex-direction: column;
+    margin-top: -12px;
     padding: 8px;
-    margin-top: 20px;
+    
+    
+    
 
     .buttonContainer {
       display: flex;
-      flex-direction: row;
       flex-wrap: wrap;
+    }
+
+    .subTitle {
+      display: flex;
+      height: 30px;
+      font-weight: normal;
+      opacity: .5;
+      font-size: 0.8em;
+
+    }
+    .timeTitles {
+      display: flex;
+      font-weight: normal;
+      opacity: .5;
+      font-size: 0.8em;
+    }
+
+    .endSubTitle {
+      margin-left: 23px;
+      position: relative;
+      bottom: -10px;
+      margin-top: -10px;
+
+    }
+
+    .startSubTitle {
+      position: relative;
+      bottom: -10px;
+      margin-top: -10px;
+
     }
 
     

--- a/src/components/SearchContainer/index.tsx
+++ b/src/components/SearchContainer/index.tsx
@@ -1,68 +1,26 @@
-// import React from 'react';
-
-// import './stylesheet.scss';
-
-// export default function SearchContainer(): React.ReactElement {
-//   return (
-//     <div className="SearchContainer">
-//       <h3 className="label">Search for a course</h3>
-//       <div className="scroller" />
-//     </div>
-//   );
-// }
-/* eslint-disable react/jsx-no-bind */
-/* eslint-disable @typescript-eslint/no-unused-vars */
-/* eslint-disable func-names */
-/* eslint-disable import/no-duplicates */
 import React, {
   ChangeEvent,
-  useEffect,
-  KeyboardEvent,
   useCallback,
   useContext,
-  useMemo,
   useRef,
   useState,
 } from 'react';
-import { AutoSizer, List } from 'react-virtualized';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faSearch } from '@fortawesome/free-solid-svg-icons';
 
-import { Course, CourseFilter } from '..';
-import { Button, Calendar, Select } from '..';
-import { OverlayCrnsContext, ScheduleContext } from '../../contexts';
-import { Combination } from '../../types';
+import { CourseFilter } from '..';
+import { ScheduleContext } from '../../contexts';
 import Modal from '../Modal';
-import {
-  ASYNC_DELIVERY_MODE,
-  CAMPUSES,
-  DELIVERY_MODES,
-  CREDIT,
-} from '../../constants';
+import { CAMPUSES, DELIVERY_MODES, CREDIT } from '../../constants';
 
 import 'react-virtualized/styles.css';
 import './stylesheet.scss';
 
 export default function SearchContainer(): React.ReactElement {
-  const [
-    { oscar, desiredCourses, pinnedCrns, excludedCrns, sortingOptionIndex },
-    { patchSchedule },
-  ] = useContext(ScheduleContext);
-  const [, setOverlayCrns] = useContext(OverlayCrnsContext);
+  const [, { patchSchedule }] = useContext(ScheduleContext);
 
   const [confirmReset, setConfirmReset] = useState(false);
-  const handleResetPinnedCrns = useCallback(() => {
-    setConfirmReset(true);
-  }, []);
 
-  const combinations = useMemo(
-    () => oscar.getCombinations(desiredCourses, pinnedCrns, excludedCrns),
-    [oscar, desiredCourses, pinnedCrns, excludedCrns]
-  );
-  const sortedCombinations = useMemo(
-    () => oscar.sortCombinations(combinations, sortingOptionIndex),
-    [oscar, combinations, sortingOptionIndex]
-  );
   const [keyword, setKeyword] = useState('');
 
   const inputRef = useRef<HTMLInputElement | null>(null);

--- a/src/components/SearchContainer/index.tsx
+++ b/src/components/SearchContainer/index.tsx
@@ -1,12 +1,182 @@
-import React from 'react';
+// import React from 'react';
 
+// import './stylesheet.scss';
+
+// export default function SearchContainer(): React.ReactElement {
+//   return (
+//     <div className="SearchContainer">
+//       <h3 className="label">Search for a course</h3>
+//       <div className="scroller" />
+//     </div>
+//   );
+// }
+/* eslint-disable react/jsx-no-bind */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable func-names */
+/* eslint-disable import/no-duplicates */
+import React, {
+  ChangeEvent,
+  useEffect,
+  KeyboardEvent,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { AutoSizer, List } from 'react-virtualized';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faSearch } from '@fortawesome/free-solid-svg-icons';
+
+import { Course, CourseFilter } from '..';
+import { Button, Calendar, Select } from '..';
+import { OverlayCrnsContext, ScheduleContext } from '../../contexts';
+import { Combination } from '../../types';
+import Modal from '../Modal';
+import {
+  ASYNC_DELIVERY_MODE,
+  CAMPUSES,
+  DELIVERY_MODES,
+  CREDIT,
+} from '../../constants';
+
+import 'react-virtualized/styles.css';
 import './stylesheet.scss';
 
 export default function SearchContainer(): React.ReactElement {
+  const [
+    { oscar, desiredCourses, pinnedCrns, excludedCrns, sortingOptionIndex },
+    { patchSchedule },
+  ] = useContext(ScheduleContext);
+  const [, setOverlayCrns] = useContext(OverlayCrnsContext);
+
+  const [confirmReset, setConfirmReset] = useState(false);
+  const handleResetPinnedCrns = useCallback(() => {
+    setConfirmReset(true);
+  }, []);
+
+  const combinations = useMemo(
+    () => oscar.getCombinations(desiredCourses, pinnedCrns, excludedCrns),
+    [oscar, desiredCourses, pinnedCrns, excludedCrns]
+  );
+  const sortedCombinations = useMemo(
+    () => oscar.sortCombinations(combinations, sortingOptionIndex),
+    [oscar, combinations, sortingOptionIndex]
+  );
+  const [keyword, setKeyword] = useState('');
+
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const handleChangeKeyword = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      let input = e.target.value.trim();
+      const results = /^([a-z]+)(\d.*)$/i.exec(input);
+      if (results != null) {
+        const [, subject, number] = results as unknown as [
+          string,
+          string,
+          string
+        ];
+        input = `${subject} ${number}`;
+      }
+      setKeyword(input);
+    },
+    []
+  );
+  type SortKey = 'deliveryMode' | 'campus' | 'creditHours';
+
+  type SortFilter = {
+    [sortKey in SortKey]: string[];
+  };
+
+  const [filter, setFilter] = useState<SortFilter>({
+    deliveryMode: [],
+    campus: [],
+    creditHours: [],
+  });
+
+  const handleResetFilter = useCallback(
+    (key) => {
+      setFilter({
+        ...filter,
+        [key]: [],
+      });
+    },
+    [filter]
+  );
+  const handleToggleFilter = useCallback(
+    (key: SortKey, tag: string) => {
+      const tags = filter[key];
+      setFilter({
+        ...filter,
+        [key]: tags.includes(tag)
+          ? tags.filter((v) => v !== tag)
+          : [...tags, tag],
+      });
+    },
+    [filter]
+  );
+
   return (
-    <div className="SearchContainer">
-      <h3 className="label">Search for a course</h3>
-      <div className="scroller" />
-    </div>
+    <>
+      <div className="CourseAdd">
+        <div className="add">
+          <div className="primary">
+            <FontAwesomeIcon className="icon" fixedWidth icon={faSearch} />
+            <div className="keyword-wrapper">
+              <input
+                type="text"
+                placeholder="Subject or course number"
+                ref={inputRef}
+                value={keyword}
+                onChange={handleChangeKeyword}
+                className="keyword"
+              />
+            </div>
+          </div>
+
+          {[
+            ['Credit Hours & Class Times', 'creditHours', CREDIT] as const,
+            ['Delivery Mode', 'deliveryMode', DELIVERY_MODES] as const,
+            ['Campus', 'campus', CAMPUSES] as const,
+          ].map(([name, property, labels]) => (
+            <CourseFilter
+              key={property}
+              name={name}
+              labels={labels}
+              selectedTags={filter[property]}
+              onReset={(): void => handleResetFilter(property)}
+              onToggle={(tag): void => handleToggleFilter(property, tag)}
+            />
+          ))}
+        </div>
+      </div>
+
+      <Modal
+        show={confirmReset}
+        onHide={(): void => setConfirmReset(false)}
+        buttons={[
+          {
+            label: 'Cancel',
+            cancel: true,
+            onClick: (): void => setConfirmReset(false),
+          },
+          {
+            label: 'Reset',
+            onClick: (): void => {
+              setConfirmReset(false);
+              patchSchedule({
+                pinnedCrns: [],
+              });
+            },
+          },
+        ]}
+      >
+        <div style={{ textAlign: 'center' }}>
+          <h2>Reset confirmation</h2>
+          <p>Are you sure you want to reset selected sections?</p>
+        </div>
+      </Modal>
+    </>
   );
 }

--- a/src/components/SearchContainer/stylesheet.scss
+++ b/src/components/SearchContainer/stylesheet.scss
@@ -44,3 +44,83 @@
     width: auto;
   }
 }
+
+.CourseAdd {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  border-right: 1px solid $color-border;
+  width: 400px;
+
+  .add {
+    @include card;
+    background-color: $color-border;
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+
+    .primary {
+      display: flex;
+      align-items: center;
+
+      .icon {
+        margin-left: 8px;
+        color: $color-neutral;
+        transition: color .2s;
+
+        &.active {
+          color: inherit;
+        }
+      }
+
+      .keyword-wrapper {
+        flex: 1;
+        display: flex;
+        align-items: center;
+        position: relative;
+        
+
+        .keyword {
+          position: relative;
+          flex-direction: row;
+          background: none;
+          border: none;
+          outline: none;
+          font-size: 1em;
+          font-weight: bold;
+          height: 40px;
+        
+          
+
+          &::placeholder {
+            font-weight: normal;
+            color: $color-neutral;
+            text-transform: none;
+          }
+
+          &.autocomplete {
+            position: absolute;
+            opacity: .5;
+          }
+        }
+      }
+    }
+  }
+
+  .Course {
+    background-color: $color-border;
+    opacity: .6;
+    transition: opacity .2s;
+
+    &:hover,
+    &.active {
+      opacity: 1;
+    }
+  }
+
+  .disclaimer {
+    color: $color-neutral;
+    padding: 4px;
+    font-size: .8em;
+  }
+}

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -1,13 +1,4 @@
-import React, {
-  ChangeEvent,
-  useEffect,
-  KeyboardEvent,
-  useCallback,
-  useContext,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import React, { ChangeEvent, useEffect, useRef, useState } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
   faCaretDown,
@@ -102,31 +93,12 @@ export default function Select<Id extends string | number>({
 
   const selectedOption = options.find((option) => option.id === current);
   const label = selectedOption ? selectedOption.label : '-';
-  const [keyword, setKeyword] = useState('');
 
   // Control inline editing state
   const [inputId, setInputId] = useState<Id | null>(null);
   const [inputValue, setInputValue] = useState<string>('');
   const [inputEditAction, setInputEditAction] = useState<EditAction<Id> | null>(
     null
-  );
-  const inputRef = useRef<HTMLInputElement | null>(null);
-
-  const handleChangeKeyword = useCallback(
-    (e: ChangeEvent<HTMLInputElement>) => {
-      let input = e.target.value.trim();
-      const results = /^([A-Z]+)(\d.*)$/i.exec(input);
-      if (results != null) {
-        const [, subject, number] = results as unknown as [
-          string,
-          string,
-          string
-        ];
-        input = `${subject} ${number}`;
-      }
-      setKeyword(input);
-    },
-    []
   );
 
   // Try to commit the edit, sending the changes to the provided callback.

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -1,4 +1,13 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, {
+  ChangeEvent,
+  useEffect,
+  KeyboardEvent,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
   faCaretDown,
@@ -93,12 +102,31 @@ export default function Select<Id extends string | number>({
 
   const selectedOption = options.find((option) => option.id === current);
   const label = selectedOption ? selectedOption.label : '-';
+  const [keyword, setKeyword] = useState('');
 
   // Control inline editing state
   const [inputId, setInputId] = useState<Id | null>(null);
   const [inputValue, setInputValue] = useState<string>('');
   const [inputEditAction, setInputEditAction] = useState<EditAction<Id> | null>(
     null
+  );
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const handleChangeKeyword = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      let input = e.target.value.trim();
+      const results = /^([A-Z]+)(\d.*)$/i.exec(input);
+      if (results != null) {
+        const [, subject, number] = results as unknown as [
+          string,
+          string,
+          string
+        ];
+        input = `${subject} ${number}`;
+      }
+      setKeyword(input);
+    },
+    []
   );
 
   // Try to commit the edit, sending the changes to the provided callback.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -92,6 +92,25 @@ const TIMES: Record<string, string> = {
   '12:30am': '12:30am',
 };
 
+const CLASS_TIMESTAMPS: Array<string> = [
+  'Any time',
+  '8:00 am',
+  '9:00 am',
+  '10:00 am',
+  '11:00 am',
+  '12:00 pm',
+  '1:00 pm',
+  '2:00 pm',
+  '3:00 pm',
+  '4:00 pm',
+  '5:00 pm',
+  '6:00 pm',
+  '7:00 pm',
+  '8:00 pm',
+  '9:00 pm',
+  '10:00 pm',
+];
+
 const BACKEND_BASE_URL = 'https://gt-scheduler.azurewebsites.net';
 
 const LARGE_DESKTOP_BREAKPOINT = 1200;
@@ -113,4 +132,5 @@ export {
   LARGE_MOBILE_BREAKPOINT,
   LARGE_DESKTOP_BREAKPOINT,
   TIMES,
+  CLASS_TIMESTAMPS,
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -74,6 +74,22 @@ const CREDIT: Record<string, string> = {
   '2 credit hours': '2.0',
   '3 credit hours': '3.0',
   '4 or more credit hours': '4.0+',
+  Monday: 'Mon',
+  Tuesday: 'Tue',
+  Wednesday: 'Wed',
+  Thursday: 'Thu',
+  Friday: 'Fri',
+  'Start Time': 'Any Time',
+  'End Time': 'Any Time',
+  Undergrad: 'Undergraduate',
+  Grad: 'Graduate',
+};
+
+const TIMES: Record<string, string> = {
+  '9:30am': '9:30am',
+  '10:30am': '10:30am',
+  '11:30am': '11:30am',
+  '12:30am': '12:30am',
 };
 
 const BACKEND_BASE_URL = 'https://gt-scheduler.azurewebsites.net';
@@ -96,4 +112,5 @@ export {
   DESKTOP_BREAKPOINT,
   LARGE_MOBILE_BREAKPOINT,
   LARGE_DESKTOP_BREAKPOINT,
+  TIMES,
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -68,6 +68,14 @@ const CAMPUSES: Record<string, string> = {
   'MBA Evening Program': 'MBA Evening',
 };
 
+const CREDIT: Record<string, string> = {
+  'No credit hours': '0.0',
+  '1 credit hours': '1.0',
+  '2 credit hours': '2.0',
+  '3 credit hours': '3.0',
+  '4 or more credit hours': '4.0+',
+};
+
 const BACKEND_BASE_URL = 'https://gt-scheduler.azurewebsites.net';
 
 const LARGE_DESKTOP_BREAKPOINT = 1200;
@@ -83,6 +91,7 @@ export {
   ASYNC_DELIVERY_MODE,
   DELIVERY_MODES,
   CAMPUSES,
+  CREDIT,
   BACKEND_BASE_URL,
   DESKTOP_BREAKPOINT,
   LARGE_MOBILE_BREAKPOINT,


### PR DESCRIPTION
## Add view for search column in Course Search tab

Issue Number(s): #2 

What does this PR change and why?
Add the draft UI of course search in "Course Search" tab (2nd column)

<img width="800" alt="image" src="https://user-images.githubusercontent.com/39681900/155656353-bf326c85-5f3f-4b16-8200-2aafc1914ba3.png">


### Checklist

- [x]  Database schema docs have been updated or are not necessary
- [x]  Code follows design and style guidelines
- [ ]  Code is commented with doc blocks
- [x]  Tests have been written and executed or are not necessary
- [x]  Latest code has been rebased from base branch (usually `develop`)
- [ ]  Commits follow guidelines (concise, squashed, etc)
- [x]  Github issues have been linked in relevant commits
- [x]  Relevant reviewers (Senior Dev/EM/Designers) have been assigned to this PR

### Critical Changes

- No critical changes

### Related PRs

- No related PRs

### How to Test

- `yarn start`
- navigate to "Course Search Tab"
- Check if the query div (2nd column) matches as described in [Figma](https://www.figma.com/file/CkystexX4qQO9OnZRxktXa/GT-Scheduler-%2F-Spr21?node-id=18%3A2)
- Check if it works on mobile view, which it should
- Double check if the 2nd column in the "Schedule" tab is working fine, bc we thought we were replacing that column with our new column
