### PR TITLE
fixed long classroom names

### DIFF
--- a/src/components/SearchResultContainer/stylesheet.scss
+++ b/src/components/SearchResultContainer/stylesheet.scss
@@ -7,6 +7,7 @@
 .SearchResultContainer {
   @include search-result-margin(13px);
   flex: 1;
+  text-overflow: ellipsis;
   display: flex;
   flex-direction: column;
   align-items: stretch;
@@ -39,6 +40,7 @@
     }
 
     .info-table {
+      text-overflow: ellipsis;
       text-align: left;
       border-collapse: collapse;
 
@@ -72,6 +74,7 @@
     .professor-header {
       align-items: center;
       background-color: #393939;
+      text-overflow: ellipsis;
       width: 100%;
       height: 40px;
       font-size: 12px;


### PR DESCRIPTION
## Long classroom names are cut off

Issue Number(s): #7

What does this PR change and why?
full classroom names should now be visible

### Checklist

- [ ]  Database schema docs have been updated or are not necessary
- [ ]  Code follows design and style guidelines
- [ ]  Code is commented with doc blocks
- [ ]  Tests have been written and executed or are not necessary
- [ ]  Latest code has been rebased from base branch (usually `develop`)
- [ ]  Commits follow guidelines (concise, squashed, etc)
- [ ]  Github issues have been linked in relevant commits
- [ ]  Relevant reviewers (Senior Dev/EM/Designers) have been assigned to this PR

### Critical Changes

- Database change / migration to run
- Environment config change
- Breaking API change

### Related PRs

- #PRNUMBER

### How to Test

1. Please add or build upon a testing card to the [Notion page](http://notion.so) and link it here
