### PR TITLE
Add spinner to third tab

### DIFF
--- a/src/components/SearchResultContainer/index.tsx
+++ b/src/components/SearchResultContainer/index.tsx
@@ -166,12 +166,14 @@ const Section = ({ section }: SectionProps): JSX.Element => {
         )}
       </td>
       <td>
-        {seating[0].length === 0
-          ? `Loading...`
-          : typeof seating[0][1] === 'number'
-          ? // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-            `${seating[0][3] ?? '<unknown>'}/${seating[0][2] ?? '<unknown>'}`
-          : `N/A`}
+        {seating[0].length === 0 ? (
+          <Spinner size="small" />
+        ) : typeof seating[0][1] === 'number' ? (
+          // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+          `${seating[0][3] ?? '<unknown>'}/${seating[0][2] ?? '<unknown>'}`
+        ) : (
+          `N/A`
+        )}
       </td>
       <td>{section.meetings[0]?.where}</td>
     </tr>

--- a/src/components/SearchResultContainer/index.tsx
+++ b/src/components/SearchResultContainer/index.tsx
@@ -9,6 +9,7 @@ import { periodToString } from '../../utils/misc';
 import { Seating } from '../../data/beans/Section';
 import { ErrorWithFields, softError } from '../../log';
 import { ScheduleContext } from '../../contexts';
+import Spinner from '../Spinner';
 
 import './stylesheet.scss';
 
@@ -16,6 +17,7 @@ type ProfessorType = {
   name: string;
   sections: SectionBean[];
   gpa: string;
+  loading: boolean;
 };
 interface CourseDetailsAPIResponse {
   header: [
@@ -41,7 +43,12 @@ interface CourseDetailsAPIResponse {
   }>;
 }
 
-const Professor = ({ name, sections, gpa }: ProfessorType): JSX.Element => {
+const Professor = ({
+  name,
+  sections,
+  gpa,
+  loading,
+}: ProfessorType): JSX.Element => {
   return (
     <>
       <tr>
@@ -149,12 +156,14 @@ const Section = ({ section }: SectionProps): JSX.Element => {
       <td>{section.meetings[0]?.days.join('')}</td>
       <td>{periodToString(section.meetings[0]?.period)}</td>
       <td>
-        {seating[0].length === 0
-          ? `Loading...`
-          : typeof seating[0][1] === 'number'
-          ? // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-            `${seating[0][1] ?? '<unknown>'}/${seating[0][0] ?? '<unknown>'}`
-          : `N/A`}
+        {seating[0].length === 0 ? (
+          <Spinner size="small" />
+        ) : typeof seating[0][1] === 'number' ? (
+          // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+          `${seating[0][1] ?? '<unknown>'}/${seating[0][0] ?? '<unknown>'}`
+        ) : (
+          `N/A`
+        )}
       </td>
       <td>
         {seating[0].length === 0
@@ -316,6 +325,7 @@ export default function SearchResultContainer({
                     key={professor}
                     name={professor}
                     sections={instructorMap[professor] ?? []}
+                    loading={gpaMap === null}
                     gpa={
                       gpaMap === null
                         ? 'Loading...'

--- a/src/components/Section/index.tsx
+++ b/src/components/Section/index.tsx
@@ -14,6 +14,7 @@ import { DELIVERY_MODES } from '../../constants';
 import { Section as SectionBean } from '../../data/beans';
 import { Seating } from '../../data/beans/Section';
 import { ErrorWithFields, softError } from '../../log';
+import Spinner from '../Spinner';
 
 import './stylesheet.scss';
 
@@ -155,13 +156,15 @@ export default function Section({
                   <b>Seats Filled</b>
                 </td>
                 <td>
-                  {seating[0].length === 0
-                    ? `Loading...`
-                    : typeof seating[0][1] === 'number'
-                    ? `${seating[0][1] ?? '<unknown>'} of ${
-                        seating[0][0] ?? '<unknown>'
-                      }`
-                    : `N/A`}
+                  {seating[0].length === 0 ? (
+                    <Spinner size="small" />
+                  ) : typeof seating[0][1] === 'number' ? (
+                    `${seating[0][1] ?? '<unknown>'} of ${
+                      seating[0][0] ?? '<unknown>'
+                    }`
+                  ) : (
+                    `N/A`
+                  )}
                 </td>
               </tr>
               <tr>
@@ -169,13 +172,15 @@ export default function Section({
                   <b>Waitlist Filled</b>
                 </td>
                 <td>
-                  {seating[0].length === 0
-                    ? `Loading...`
-                    : typeof seating[0][1] === 'number'
-                    ? `${seating[0][3] ?? '<unknown>'} of ${
-                        seating[0][2] ?? '<unknown>'
-                      }`
-                    : `N/A`}
+                  {seating[0].length === 0 ? (
+                    <Spinner size="small" />
+                  ) : typeof seating[0][1] === 'number' ? (
+                    `${seating[0][3] ?? '<unknown>'} of ${
+                      seating[0][2] ?? '<unknown>'
+                    }`
+                  ) : (
+                    `N/A`
+                  )}
                 </td>
               </tr>
             </tbody>


### PR DESCRIPTION
## Add spinner to third tab

Issue Number(s): #31 

What does this PR change and why?
Adds a spinner to the third tab on load

https://user-images.githubusercontent.com/39681900/192130577-b698a5c8-09e1-4ff4-a698-229859edc9ac.mov

### Checklist

- [x]  Database schema docs have been updated or are not necessary
- [x]  Code follows design and style guidelines
- [x]  Code is commented with doc blocks
- [x]  Tests have been written and executed or are not necessary
- [x]  Latest code has been rebased from base branch (usually `develop`)
- [x]  Commits follow guidelines (concise, squashed, etc)
- [x]  Github issues have been linked in relevant commits
- [x]  Relevant reviewers (Senior Dev/EM/Designers) have been assigned to this PR

### Critical Changes
- None

### Related PRs
- None

### How to Test

1. Go to third tab
2. Search for a course
3. Click on the "i" symbol that shows up on the card in the second column
4. Verify that a spinner shows up instead of `loading...` text on the column values on the table on the left
